### PR TITLE
Add ‘Bypass If In "dev" Environment’ setting (or maybe not)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can also add the package to your project using Composer.
         cd /path/to/project
 
 2. Then tell Composer to load the plugin:
-    
+
         composer require verbb/knock-knock
 
 3. In the Control Panel, go to Settings → Plugins and click the “Install” button for Knock Knock.
@@ -41,11 +41,12 @@ return [
         'siteSettings' => [],
 
         'checkInvalidLogins' => false,
+        'bypassInDevEnvironment' => false,
         'invalidLoginWindowDuration' => '3600',
         'maxInvalidLogins' => 10,
         'whitelistIps' => '',
         'blacklistIps' => '',
-        
+
         'protectedUrls' = '',
     ],
     'staging' => [
@@ -62,7 +63,8 @@ return [
 - `template` - Provide a path to a custom template to be shown instead of the default one.
 - `forcedRedirect` - Provide a URL to be redirected to when logging in. Knock Knock will try and redirect to the referring URL, but you may want to enforce a specific URL to always go to.
 - `siteSettings` - See below on how to configure.
-- `checkInvalidLogins` - Whether to check and log invalid logins. This will lock IP addresses out of the system in certain circumstances, but can help against brute-force logins..
+- `checkInvalidLogins` - Whether to check and log invalid logins. This will lock IP addresses out of the system in certain circumstances, but can help against brute-force logins.
+- `bypassInDevEnvironment` - Whether to bypass Knock Knock if the current environment is set to "dev" in your .env file.
 - `invalidLoginWindowDuration` - The amount of time to track invalid login attempts for an IP, for determining if Knock Knock should lock the IP out.
 - `maxInvalidLogins` - The number of invalid login attempts Knock Knock will allow within the specified duration before the IP gets locked.
 - `whitelistIps` - Provide IP Addresses that should be exempt from lockouts out automatically.

--- a/src/KnockKnock.php
+++ b/src/KnockKnock.php
@@ -86,6 +86,11 @@ class KnockKnock extends Plugin
                 return;
             }
 
+            // Don't block access if we're in dev mode and dev bypass is on
+            if (CRAFT_ENVIRONMENT == 'dev' && $settings->getBypassInDevEnvironment() == true) {
+              return;
+            }
+
             $url = $request->getAbsoluteUrl();
             $cookie = $request->getCookies()->get('siteAccessToken');
             $loginPath = $settings->getLoginPath();
@@ -94,7 +99,7 @@ class KnockKnock extends Plugin
             if ($cookie != '' || stripos($url, $loginPath) !== false) {
                 return;
             }
-            
+
             $ipAddress = $request->getUserIP();
 
             // Check if this IP is in the exclusion list

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -11,7 +11,7 @@ class Settings extends Model
 {
     // Public Properties
     // =========================================================================
-    
+
     public $enabled = false;
     public $password;
     public $loginPath;
@@ -20,6 +20,7 @@ class Settings extends Model
     public $siteSettings = [];
 
     public $checkInvalidLogins = false;
+    public $bypassInDevEnvironment = false;
     public $invalidLoginWindowDuration = '3600';
     public $maxInvalidLogins = 10;
     public $whitelistIps;
@@ -59,6 +60,11 @@ class Settings extends Model
     public function getBlacklistIps()
     {
         return explode("\n", $this->blacklistIps) ?? [];
+    }
+
+    public function getBypassInDevEnvironment()
+    {
+        return $this->_getSettingValue('bypassInDevEnvironment') ?? false;
     }
 
     public function getProtectedUrls()

--- a/src/templates/settings/_panes/security.html
+++ b/src/templates/settings/_panes/security.html
@@ -13,6 +13,17 @@
     warning: macros.configWarning('checkInvalidLogins', 'knock-knock'),
 }) }}
 
+{{ forms.lightswitchField({
+    label: 'Bypass If In "dev" Environment' | t('knock-knock'),
+    instructions: 'Whether to bypass Knock Knock if the current environment is set to "dev" in your .env file' | t('knock-knock'),
+    id: 'bypassInDevEnvironment',
+    name: 'bypassInDevEnvironment',
+    value: 1,
+    on: settings.bypassInDevEnvironment,
+    errors: settings.getErrors('bypassInDevEnvironment'),
+    warning: macros.configWarning('bypassInDevEnvironment', 'knock-knock'),
+}) }}
+
 {{ forms.textField({
     label: 'Invalid Login Window Duration' | t('knock-knock'),
     instructions: 'The amount of time to track invalid login attempts for an IP, for determining if Knock Knock should lock the IP out.' | t('knock-knock'),


### PR DESCRIPTION
**EDIT: build this and then realised it's doable via one line in the "config/knock-knock.php" file, d'oh! So feel free to ignore this if it wouldn't be a helpful addition, just wanted to practice my plugin dev really :)**

----

To give people the option to skip the Knock Knock prompt when developing locally.

Handy because pulling down a copy of the Craft database from staging or elsewhere logs you out of the CP and means the next thing you see is Knock Knock.