### PR TITLE
Use getAllowIps after deprecating whitelistIps

### DIFF
--- a/src/KnockKnock.php
+++ b/src/KnockKnock.php
@@ -99,7 +99,7 @@ class KnockKnock extends Plugin
             $ipAddress = $request->getRemoteIP();
 
             // Check if this IP is in the exclusion list
-            if (in_array($ipAddress, $settings->getWhitelistIps())) {
+            if (in_array($ipAddress, $settings->getAllowIps())) {
                 return;
             }
 


### PR DESCRIPTION
f649cdbecf7f4771ba0dfd6adeb2a88c7e0dba94 deprecated the `whitelistIps` setting, but the exclusion list check was still using this getter. This PR changes it to `getAllowIps`.