### PR TITLE
Add support for IPv4 and IPv6 CIDR blocks in allowIps and denyIps config

### DIFF
--- a/src/KnockKnock.php
+++ b/src/KnockKnock.php
@@ -2,6 +2,7 @@
 namespace verbb\knockknock;
 
 use verbb\knockknock\base\PluginTrait;
+use verbb\knockknock\helpers\IpHelper;
 use verbb\knockknock\models\Settings;
 
 use Craft;
@@ -10,7 +11,6 @@ use craft\events\RegisterUrlRulesEvent;
 use craft\helpers\UrlHelper;
 use craft\services\Plugins;
 use craft\web\UrlManager;
-
 use yii\base\Event;
 
 class KnockKnock extends Plugin
@@ -103,7 +103,7 @@ class KnockKnock extends Plugin
             }
 
             // Check if this IP is in the exclusion list
-            if (in_array($ipAddress, $settings->getAllowIps())) {
+            if (IpHelper::ipInCidrList($ipAddress, $settings->getAllowIps())) {
                 return;
             }
 

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -2,11 +2,11 @@
 namespace verbb\knockknock\controllers;
 
 use verbb\knockknock\KnockKnock;
+use verbb\knockknock\helpers\IpHelper;
 use verbb\knockknock\models\Login;
 
 use Craft;
 use craft\web\Controller;
-
 use yii\web\Cookie;
 use yii\web\Response;
 
@@ -108,7 +108,7 @@ class DefaultController extends Controller
                 $login->password = $password;
 
                 // No need to log allow list
-                if (!in_array($ipAddress, $settings->getAllowIps())) {
+                if (!IpHelper::ipInCidrList($ipAddress, $settings->getAllowIps())) {
                     KnockKnock::$plugin->getLogins()->saveLogin($login);
                 }
             }

--- a/src/helpers/IpHelper.php
+++ b/src/helpers/IpHelper.php
@@ -1,0 +1,115 @@
+<?php
+namespace verbb\knockknock\helpers;
+
+class IpHelper
+{
+	// Public Methods
+    // =========================================================================
+	
+	/**
+	 * Check if IP exists in list of IP addresses and CIDR blocks
+	 *
+	 * @param string $ip
+	 * @param array $cidrList
+	 */
+	public static function ipInCidrList($ip, $cidrList)
+	{
+		$ip_bits = self::_ipToBits($ip);
+
+		if($ip_bits === false)
+			return false;
+
+		foreach($cidrList as $cidrnet){
+			$maskbits = false;
+			$ip_net_bits = $ip_bits;
+
+			if(strpos($cidrnet, '/') === false){
+				$net = $cidrnet;
+			}else{
+				list($net,$maskbits)=explode('/',$cidrnet);
+			}
+
+			$net_bits = self::_ipToBits($net);
+
+			if(!empty($maskbits)){
+				$ip_net_bits	= substr($ip_net_bits, 0, $maskbits);
+				$net_bits		= substr($net_bits, 0, $maskbits);
+			}
+
+			if($ip_net_bits === $net_bits)
+				return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Validate IP or CIDR block
+	 *
+	 * @param string $cidr
+	 */
+	public static function validIpOrCidr($cidr)
+	{
+		if (!preg_match("/^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(\/[0-9]{1,2})?$/", $cidr))
+		{
+			$return = false;
+		} else
+		{
+			$return = true;
+		}
+		if ($return == true)
+		{
+			$parts = explode("/", $cidr);
+			$ip = $parts[0];
+			$netmask = '';
+			if(isset($parts[1]))
+				$netmask = $parts[1];
+			$octets = explode(".", $ip);
+			foreach ($octets as $octet)
+			{
+				if ($octet > 255)
+				{
+					$return = false;
+				}
+			}
+			if (($netmask != "") && ($netmask > 32))
+			{
+				$return = false;
+			}
+		} elseif (preg_match("/^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))(\/[0-9]{1,2})?$/", $cidr))
+		{ /* Seems invalid, check if valid ipv6 */
+			$return = true;
+		}		
+		return $return;
+	}
+	
+	// Private methods
+    // =========================================================================
+	
+	/**
+	 * Converts inet_pton output to string with bits
+	 *
+	 * @param string $ip
+	 */
+	private static function _ipToBits($ip)
+	{
+		$inet = @inet_pton($ip);
+		if($inet === false)
+			return false;
+
+		if(strpos($ip, ":") === false){
+			$unpacked = unpack('a4', $inet);
+		}else{
+			$unpacked = unpack('a16', $inet);
+		}
+
+		$unpacked = str_split($unpacked[1]);
+
+		$binaryip = '';
+		foreach ($unpacked as $char) {
+			$binaryip .= str_pad(decbin(ord($char)), 8, '0', STR_PAD_LEFT);
+		}
+		return $binaryip;
+	}
+	
+}

--- a/src/services/Logins.php
+++ b/src/services/Logins.php
@@ -2,6 +2,7 @@
 namespace verbb\knockknock\services;
 
 use verbb\knockknock\KnockKnock;
+use verbb\knockknock\helpers\IpHelper;
 use verbb\knockknock\models\Login;
 use verbb\knockknock\records\Login as LoginRecord;
 
@@ -9,7 +10,6 @@ use Craft;
 use craft\db\Query;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Db;
-
 use yii\base\Component;
 use yii\base\Exception;
 
@@ -66,11 +66,11 @@ class Logins extends Component
         $settings = KnockKnock::$plugin->getSettings();
 
         // Check for allow/deny
-        if (in_array($ipAddress, $settings->getAllowIps())) {
+        if (IpHelper::ipInCidrList($ipAddress, $settings->getAllowIps())) {
             return false;
         }
         
-        if (in_array($ipAddress, $settings->getDenyIps())) {
+        if (IpHelper::ipInCidrList($ipAddress, $settings->getDenyIps())) {
             return true;
         }
 


### PR DESCRIPTION
Allow usage of IP ranges in the form of [CIDR blocks](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) in the allowIps and denyIps config settings.

This for exapmle makes it possible to whitelist an IPv6 prefix instead of the full IPv6 address that changes regularly.