### PR TITLE
Support custom CP templates

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -39,8 +39,14 @@ class DefaultController extends Controller
         $template = 'knock-knock/ask';
 
         if ($settings->getTemplate()) {
-            $view->setTemplateMode($view::TEMPLATE_MODE_SITE);
+            // try CP template first
             $template = $settings->getTemplate();
+            
+            if (!$template) {
+                // try site template if cp template does not exist
+                $view->setTemplateMode($view::TEMPLATE_MODE_SITE);
+                $template = $settings->getTemplate();
+            }
         }
 
         $redirect = Craft::$app->getSession()->get('knockknock-redirect');
@@ -65,8 +71,14 @@ class DefaultController extends Controller
         $template = 'knock-knock/ask';
 
         if ($settings->getTemplate()) {
-            $view->setTemplateMode($view::TEMPLATE_MODE_SITE);
+            // try CP template first
             $template = $settings->getTemplate();
+            
+            if (!$template) {
+                // try site template if cp template does not exist
+                $view->setTemplateMode($view::TEMPLATE_MODE_SITE);
+                $template = $settings->getTemplate();
+            }
         }
 
         $ipAddress = Craft::$app->getRequest()->getRemoteIP();


### PR DESCRIPTION
Currently only site templates are supported as custom templates. This can be cumbersome in case additional features need to be added to the template behind knock-knock/who-is-there, as this required to rebuild an entire site template and not being able to use the CP templates features e.g. just to add a button or text to the template.

This PR tests if the custom template is a CP or a site template and renders with the corresponding template mode.