### PR TITLE
Allow arrays in config settings

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -11,7 +11,7 @@ class Settings extends Model
 {
     // Public Properties
     // =========================================================================
-    
+
     public $enabled = false;
     public $password;
     public $loginPath;
@@ -97,12 +97,16 @@ class Settings extends Model
     // Private Methods
     // =========================================================================
 
-    private function _getArrayFromMultiline($string)
+    private function _getArrayFromMultiline($value)
     {
+        if (is_array($value)) {
+            return $value;
+        }
+
         $array = [];
 
-        if ($string) {
-            $array = array_map('trim', explode(PHP_EOL, $string));
+        if ($value) {
+            $array = array_map('trim', explode(PHP_EOL, $value));
         }
 
         return $array;


### PR DESCRIPTION
When using a php config file for the plugin settings, only an ugly way of using multiple ip's or urls is supported. The pull request adds support for arrays.

Example:

Before:

```php
return [
    '*' => [
        'enabled' => true,
        'allowIps' => '0.0.0.0
0.0.0.1',
    ],
];
```

After:

```php
return [
    '*' => [
        'enabled' => true,
        'allowIps' => ['0.0.0.0', '0.0.0.1'],
    ],
];
```
